### PR TITLE
Add AI assistant tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import { LayoutDashboard, BarChart as ChartBar } from 'lucide-react';
+import { LayoutDashboard, BarChart as ChartBar, Bot } from 'lucide-react';
 import Header from './components/Header';
 import FileUpload from './components/FileUpload';
 import OptimizationForm from './components/OptimizationForm';
@@ -10,6 +10,7 @@ import Pdfexport from './components/Pdfexport'; // Import the Pdfexport componen
 import AnalyticsView from './components/AnalyticsView';
 import LoginPage from './components/LoginPage'; // Import LoginPage component
 import OptimizationSuggestions from './components/OptimizationSuggestions';
+import AiAssistant from './components/AiAssistant';
 import { OptimizationResult, OptimizationSummary } from './types/types';
 import { useDarkMode } from './hooks/useDarkMode';
 import { optimizeUpsWithPlates } from './utils/optimizer';
@@ -22,7 +23,7 @@ function App() {
   const [results, setResults] = useState<OptimizationResult[] | null>(null);
   const [summary, setSummary] = useState<OptimizationSummary | null>(null);
   const [calculating, setCalculating] = useState<boolean>(false);
-  const [activeTab, setActiveTab] = useState<'results' | 'analytics'>('results');
+  const [activeTab, setActiveTab] = useState<'results' | 'analytics' | 'assistant'>('results');
   const { darkMode, toggleDarkMode } = useDarkMode();
 
   const handleCsvUpload = (
@@ -171,6 +172,17 @@ function App() {
                           <ChartBar size={18} className="inline-block mr-2" />
                           Analytics
                         </button>
+                        <button
+                          className={`py-3 px-4 border-b-2 font-medium text-sm transition-colors ${
+                            activeTab === 'assistant'
+                              ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                              : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400'
+                          }`}
+                          onClick={() => setActiveTab('assistant')}
+                        >
+                          <Bot size={18} className="inline-block mr-2" />
+                          Assistant
+                        </button>
                       </div>
                     </div>
 
@@ -184,8 +196,10 @@ function App() {
                             </div>
                           )}
                         </>
-                      ) : (
+                      ) : activeTab === 'analytics' ? (
                         <AnalyticsView results={results} />
+                      ) : (
+                        <AiAssistant summary={summary} />
                       )}
                     </div>
                   </div>

--- a/src/components/AiAssistant.tsx
+++ b/src/components/AiAssistant.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { OptimizationSummary } from '../types/types';
+
+interface AiAssistantProps {
+  summary: OptimizationSummary | null;
+}
+
+function getAiResponse(message: string, summary: OptimizationSummary | null): string {
+  const text = message.toLowerCase();
+  if (!summary) {
+    return 'Please run an optimization first so I can analyze the results.';
+  }
+  if (text.includes('summary') || text.includes('stats')) {
+    return `Total sheets: ${summary.totalSheets}, produced: ${summary.totalProduced}, waste: ${summary.wastePercentage.toFixed(1)}%.`;
+  }
+  if (text.includes('reduce') && text.includes('waste')) {
+    return summary.wastePercentage < 5
+      ? 'Great job! Your waste is already quite low.'
+      : 'Consider trying different UPS values or adjusting plate count to reduce waste.';
+  }
+  return "I'm here to answer questions about your optimization results. Try asking about the summary or how to reduce waste.";
+}
+
+const AiAssistant: React.FC<AiAssistantProps> = ({ summary }) => {
+  const [messages, setMessages] = useState<Array<{ from: 'user' | 'ai'; text: string }>>([
+    { from: 'ai', text: "Hello! I'm your optimization assistant. Ask me about your results!" }
+  ]);
+  const [input, setInput] = useState('');
+
+  const handleSend = () => {
+    const text = input.trim();
+    if (!text) return;
+    const response = getAiResponse(text, summary);
+    setMessages(prev => [...prev, { from: 'user', text }, { from: 'ai', text: response }]);
+    setInput('');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="max-h-60 overflow-y-auto space-y-2">
+        {messages.map((msg, idx) => (
+          <div
+            key={idx}
+            className={`p-2 rounded-md shadow-sm w-fit fade-in-up ${
+              msg.from === 'user'
+                ? 'ml-auto bg-blue-500 text-white'
+                : 'mr-auto bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
+            }`}
+          >
+            {msg.text}
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          className="flex-1 border rounded-md px-3 py-2 dark:bg-gray-800 dark:border-gray-700"
+          placeholder="Ask me about your results..."
+        />
+        <button
+          onClick={handleSend}
+          className="bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600 transition-colors"
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AiAssistant;

--- a/src/index.css
+++ b/src/index.css
@@ -109,3 +109,11 @@ table tbody td {
 .fade-in {
   animation: fadeIn 0.3s ease-out forwards;
 }
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.fade-in-up {
+  animation: fadeInUp 0.4s ease-out forwards;
+}


### PR DESCRIPTION
## Summary
- add simple AI Assistant tab and chat component
- provide fade-in-up animation utility in CSS
- integrate new tab in App

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849fadc7280832dbd8b4878a657ddb9